### PR TITLE
WIP: Add "included" support

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const { readFileSync } = require('fs');
 const { join } = require('path');
 
 const AuthorsArray  = require('./lib/authors-array');
+const AddIncludedJson = require('./lib/add-included-json');
 
 module.exports = {
   name: 'empress-blog',
@@ -119,7 +120,13 @@ module.exports = {
       }]
     });
 
-    const trees = [contentTree, pageTree, authorTree];
+    const includedTree = new AddIncludedJson(MergeTrees([contentTree, pageTree, authorTree]), {
+      include: {
+        content: ['author']
+      }
+    });
+
+    const trees = [contentTree, pageTree, authorTree, includedTree];
 
     const config = this.project.config(process.env.EMBER_ENV || 'development');
 
@@ -138,7 +145,7 @@ module.exports = {
       }
     }
 
-    return MergeTrees(trees);
+    return MergeTrees(trees, { overwrite: true });
   },
 
   contentFor(type, config) {

--- a/lib/add-included-json.js
+++ b/lib/add-included-json.js
@@ -1,0 +1,105 @@
+const BroccoliPlugin = require('broccoli-plugin');
+const walkSync = require('walk-sync');
+const { readFileSync, writeFileSync, existsSync } = require('fs');
+const mkdirp = require('mkdirp');
+const { join, dirname } = require('path');
+const Inflector = require('inflected');
+
+module.exports = class AddIncludedJson extends BroccoliPlugin {
+  constructor(folder, options) {
+    super([folder], options);
+
+    //TODO assign default value to options
+    this.options = options || {};
+  }
+
+  build() {
+    const folders = Object.keys(this.options.include);
+
+    // here we take the assumption that we can only "include" data for which a json file exists
+    const allFolders = [...new Set([
+      ...folders,
+      ...Object.values(this.options.include).flat()
+    ])];
+
+    // load the relevant JSON into a map
+    const jsonPerFolder = new Map();
+    this.inputPaths.forEach((dir) => {
+      allFolders.forEach(folder => {
+        const jsonFiles = walkSync(join(dir, folder))
+          .filter(path => path.endsWith('.json'));
+
+        jsonFiles.forEach(file => {
+          const filePath = join(folder, file);
+          const fileData = {
+            path: filePath,
+            json: JSON.parse(readFileSync(join(dir, filePath)))
+          };
+
+          if(jsonPerFolder.has(folder)){
+            jsonPerFolder.set(folder, [...jsonPerFolder.get(folder), fileData]);
+          } else {
+            jsonPerFolder.set(folder, [fileData]);
+          }
+        });
+      });
+
+      folders.forEach(folder => {
+        const toInclude = this.options.include[folder];
+
+        jsonPerFolder.get(folder).forEach(jsonItem => {
+          const filePath = jsonItem.path;
+          const resource = jsonItem.json;
+
+          toInclude.map(type => {
+            let included;
+            if(Array.isArray(resource.data)){
+              included = getIncluded(type, resource.data, jsonPerFolder);
+            } else {
+              included = getIncluded(type, [resource.data], jsonPerFolder);
+            }
+
+            const outputFilePath = join(this.outputPath, filePath);
+            mkdirp.sync(dirname(outputFilePath));
+            writeFileSync(outputFilePath, JSON.stringify({
+              ...resource,
+              included
+            }));
+          });
+        })
+      });
+    });
+  }
+};
+
+function getIncluded(type, resources, jsonPerFolder){
+  let included = [];
+
+  resources.forEach(resource => {
+    if(resource.relationships){
+      const relationships = resource.relationships;
+
+      //TODO: is there ever a non plural relationship? (one-to-x)
+      const pluralType = Inflector.pluralize(type);
+      let relData;
+      if(Object.keys(resource.relationships).includes(type)){
+        relData = relationships[type];
+      } else if(Object.keys(relationships).includes(pluralType)){
+        relData = relationships[pluralType];
+      } else {
+        //TODO: throw error?
+      }
+
+      const ids = Array.isArray(relData.data)
+        ? relData.data.map(obj => obj.id)
+        : [relData.data.id];
+
+      included = included.concat(jsonPerFolder
+        .get(type)
+        .filter(r => ids.includes(r.json.data.id))
+        .map(r => r.json.data));
+    }
+  });
+
+  return [...new Set(included)];
+}


### PR DESCRIPTION
Initial stab at adding support for "included" in the output JSON.

To define what is included where you can pass an "include" object in the options of the plugin. The keys denote for which resources to add includes and the value (array) denotes the resource types to include.

Couple of notes/questions:
- We need to use the (same) inflected module as jsonapi-serializer uses in order to get the proper plural (type) from the input type/folder. This is needed so we know what key to use to look for the relationships. We could either add the same `inflected@^1.1.6` as `jsonapi-serializer` or use the re-export from `jsonapi-serializer`.
- @mansona you seemed to have quite a specific idea of how you wanted the plugin API to be. Let me know if any changes are necessary.
- As opposed to `author-array` I had to create the folder before writing the file. As this is the first time I've worked on a broccoli plugin I do not know if this is the correct way.
- Current setup requires `overwrite: true` in MergeTrees which is eh.
- I've used destructuring/sets and what not. I saw there's also lodash available. Any specific reason why that was used? I haven't checked everything yet.. but afaik node 6 should support it.
- ???