### PR TITLE
swap `sh` with `bash` for default content code blocks to support Prism

### DIFF
--- a/blueprints/empress-blog/files/__base__/content/themes.md
+++ b/blueprints/empress-blog/files/__base__/content/themes.md
@@ -17,7 +17,7 @@ The [empress-blog documentation](https://github.com/empress/empress-blog/blob/ma
 
 If you are interested in writing your own theme for empress-blog you can get started using
 
-```sh
+```bash
 npm init empress-blog-template <template-name>
 ```
 and it will create a brand new template addon in the folder `empress-blog-template-name-template`! You can check out the documentation for [create-empress-blog-template here](https://github.com/empress/create-empress-blog-template#readme). As [Ghost](https://ghost.org/) uses handlebars it is not too difficult to port an existing Ghost template to use Ember templates, so if you have any requests for an existing open source Ghost template please let us know 👍

--- a/blueprints/empress-blog/files/__base__/content/welcome.md
+++ b/blueprints/empress-blog/files/__base__/content/welcome.md
@@ -27,7 +27,7 @@ We know that first impressions are important, so we've populated your new site w
 
 ### Quick Start
 
-```sh
+```bash
 # if you don't have ember-cli installed already
 npm install -g ember-cli
 

--- a/tests/dummy/content/themes.md
+++ b/tests/dummy/content/themes.md
@@ -17,7 +17,7 @@ The [empress-blog documentation](https://github.com/empress/empress-blog/blob/ma
 
 If you are interested in writing your own theme for empress-blog you can get started using
 
-```sh
+```bash
 npm init empress-blog-template <template-name>
 ```
 and it will create a brand new template addon in the folder `empress-blog-template-name-template`! You can check out the documentation for [create-empress-blog-template here](https://github.com/empress/create-empress-blog-template#readme). As [Ghost](https://ghost.org/) uses handlebars it is not too difficult to port an existing Ghost template to use Ember templates, so if you have any requests for an existing open source Ghost template please let us know 👍

--- a/tests/dummy/content/welcome.md
+++ b/tests/dummy/content/welcome.md
@@ -27,7 +27,7 @@ We know that first impressions are important, so we've populated your new site w
 
 ### Quick Start
 
-```sh
+```bash
 # if you don't have ember-cli installed already
 npm install -g ember-cli
 


### PR DESCRIPTION
Prism does not seem to support `sh` as a language key, so we can swap it with `bash` in order to get highlighting for this.

Using `sh` with `ember-showdown-prism` currently gives a nasty unreadable error when a language is not recognized (will be "fixed" by https://github.com/empress/ember-showdown-prism/pull/5 ).