### PR TITLE
update ember-responsive-image

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^3.4.1",
     "ember-resolver": "^5.0.1",
-    "ember-responsive-image": "^1.0.0-rc.6",
+    "ember-responsive-image": "^1.0.0-rc.7",
     "ember-source": "~3.9.0",
     "ember-source-channel-url": "^1.1.0",
     "ember-try": "^1.2.1",


### PR DESCRIPTION
This just makes sure that we don't get the issue with sharp not building on new node versions 👍 