### PR TITLE
fix sorting in paginated content

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = {
       collationFileName: 'content.json',
       paginate: blogConfig.paginate,
       paginateSortFunction(a, b) {
-        return b.date - a.date;
+        return new Date(b.data.attributes.date) - new Date(a.data.attributes.date);
       }
     });
 


### PR DESCRIPTION
I guess I never tested this 🙃  this would never have worked because

- the date was undefined (because of JSON:API structure) 
- the date was a string so it would have been a strange sorting order

