### PR TITLE
Revert "replace naive scroll to top implementation with ember-scroll"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
 
 before_install:
   - npm config set spin false
-  - npm install -g npm@6
+  - npm install -g npm@7
   - npm --version
   - npm install -g @lhci/cli@0.5.x
 

--- a/app/components/link-to.js
+++ b/app/components/link-to.js
@@ -1,0 +1,9 @@
+import LinkComponent from '@ember/routing/link-component';
+
+export default LinkComponent.extend({
+  click() {
+    if(window.scrollTo) {
+      window.scrollTo(0,0);
+    }
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "ember-cli-string-utils": "^1.1.0",
         "ember-get-config": "^0.2.4",
         "ember-meta": "^0.5.0",
-        "ember-scroll": "^1.0.0",
         "empress-blueprint-helpers": "^1.2.1",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.20",
@@ -1796,7 +1795,8 @@
     "node_modules/@ember/edition-utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ember/edition-utils/-/edition-utils-1.2.0.tgz",
-      "integrity": "sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog=="
+      "integrity": "sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==",
+      "dev": true
     },
     "node_modules/@ember/optional-features": {
       "version": "0.6.4",
@@ -7772,6 +7772,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
       "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -13512,248 +13513,6 @@
         "recast": "^0.11.3"
       }
     },
-    "node_modules/ember-scroll": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-scroll/-/ember-scroll-1.0.0.tgz",
-      "integrity": "sha512-EtabLVL2ZJYvV+VNKLG8Bo6NQ129LlDkjs0Rtkg6mslex2ihAR/hdXDR5yVAWqrAlLfZTrUIGnXCte75tWtM0w==",
-      "dependencies": {
-        "ember-cli-babel": "^7.21.0",
-        "ember-cli-htmlbars": "^5.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/babel-plugin-htmlbars-inline-precompile": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-4.2.0.tgz",
-      "integrity": "sha512-n2jMGcFKvubnYi8Ink7zJnC+aQor97v5FJKYUOUKijj5gIDy/sOIAZ7BxDWb0co1VzZokdN7tvtLnQtiWfD1Gw==",
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
-      "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/broccoli-plugin": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
-      "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
-      "dependencies": {
-        "broccoli-node-api": "^1.6.0",
-        "broccoli-output-wrapper": "^3.2.1",
-        "fs-merger": "^3.1.0",
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.3.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ember-scroll/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/editions/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/ember-cli-htmlbars": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.3.1.tgz",
-      "integrity": "sha512-ZjQTt44euDoqLvUkWbt1svgNCXgLzOztEbc2qqYMQvhQig416LMrWK7l3SSbNU+BtLD5UIxmwvLfF1tsO2CVyA==",
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^4.2.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.0",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.0",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.2",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/matcher-collection": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/ember-scroll/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/sync-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.6",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-scroll/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
     "node_modules/ember-source": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.9.1.tgz",
@@ -14884,6 +14643,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/errlop/-/errlop-2.2.0.tgz",
       "integrity": "sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==",
+      "dev": true,
       "engines": {
         "node": ">=0.8"
       },
@@ -29275,7 +29035,8 @@
     "@ember/edition-utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ember/edition-utils/-/edition-utils-1.2.0.tgz",
-      "integrity": "sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog=="
+      "integrity": "sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==",
+      "dev": true
     },
     "@ember/optional-features": {
       "version": "0.6.4",
@@ -34523,7 +34284,8 @@
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -39529,184 +39291,6 @@
         "recast": "^0.11.3"
       }
     },
-    "ember-scroll": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-scroll/-/ember-scroll-1.0.0.tgz",
-      "integrity": "sha512-EtabLVL2ZJYvV+VNKLG8Bo6NQ129LlDkjs0Rtkg6mslex2ihAR/hdXDR5yVAWqrAlLfZTrUIGnXCte75tWtM0w==",
-      "requires": {
-        "ember-cli-babel": "^7.21.0",
-        "ember-cli-htmlbars": "^5.2.0"
-      },
-      "dependencies": {
-        "async-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.3",
-            "istextorbinary": "^2.5.1",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "rsvp": "^4.8.5",
-            "username-sync": "^1.0.2"
-          }
-        },
-        "babel-plugin-htmlbars-inline-precompile": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-4.2.0.tgz",
-          "integrity": "sha512-n2jMGcFKvubnYi8Ink7zJnC+aQor97v5FJKYUOUKijj5gIDy/sOIAZ7BxDWb0co1VzZokdN7tvtLnQtiWfD1Gw=="
-        },
-        "broccoli-persistent-filter": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
-          "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
-          "requires": {
-            "async-disk-cache": "^2.0.0",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^4.0.3",
-            "fs-tree-diff": "^2.0.0",
-            "hash-for-dep": "^1.5.0",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^3.0.0",
-            "symlink-or-copy": "^1.0.1",
-            "sync-disk-cache": "^2.0.0"
-          }
-        },
-        "broccoli-plugin": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
-          "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
-          "requires": {
-            "broccoli-node-api": "^1.6.0",
-            "broccoli-output-wrapper": "^3.2.1",
-            "fs-merger": "^3.1.0",
-            "promise-map-series": "^0.2.1",
-            "quick-temp": "^0.1.3",
-            "rimraf": "^3.0.0",
-            "symlink-or-copy": "^1.3.0"
-          }
-        },
-        "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "editions": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-          "requires": {
-            "errlop": "^2.0.0",
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            }
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.3.1.tgz",
-          "integrity": "sha512-ZjQTt44euDoqLvUkWbt1svgNCXgLzOztEbc2qqYMQvhQig416LMrWK7l3SSbNU+BtLD5UIxmwvLfF1tsO2CVyA==",
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^4.2.0",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^3.1.0",
-            "broccoli-plugin": "^4.0.3",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.0",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^7.3.2",
-            "silent-error": "^1.1.1",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "istextorbinary": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-          "requires": {
-            "binaryextensions": "^2.1.2",
-            "editions": "^2.2.0",
-            "textextensions": "^2.5.0"
-          }
-        },
-        "matcher-collection": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-        },
-        "strip-bom": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
-        },
-        "sync-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.6",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "username-sync": "^1.0.2"
-          }
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        }
-      }
-    },
     "ember-source": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.9.1.tgz",
@@ -40646,7 +40230,8 @@
     "errlop": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/errlop/-/errlop-2.2.0.tgz",
-      "integrity": "sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw=="
+      "integrity": "sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==",
+      "dev": true
     },
     "errno": {
       "version": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ember-cli-string-utils": "^1.1.0",
     "ember-get-config": "^0.2.4",
     "ember-meta": "^0.5.0",
-    "ember-scroll": "^1.0.0",
     "empress-blueprint-helpers": "^1.2.1",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.20",


### PR DESCRIPTION
This reverts the move to ember-scroll as we figured out (by adding an acceptance test in #91) that this should have been a major release. We're reverting, I will release a patch version and then we can reply the commit and the following release will be a major