### PR TITLE
fix: update Tag serializer to use _postIds instead of postIds

### DIFF
--- a/app/serializers/tag.js
+++ b/app/serializers/tag.js
@@ -3,7 +3,7 @@ import ApplicationSerializer from './application';
 export default ApplicationSerializer.extend({
   normalize() {
     let tag = this._super(...arguments);
-    tag.data.attributes.postIds = tag.data.relationships.posts?.data.map(p => p.id) ?? [];
+    tag.data.attributes._postIds = tag.data.relationships.posts?.data.map(p => p.id) ?? [];
     return tag;
   }
 });


### PR DESCRIPTION
We forgot to update the serializer after updating #61 to be _postIds instead of postIds.