### PR TITLE
add support for posts without tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,9 @@ Please generate tags using 'ember generate tag your-tag-name'`);
         const fileContents = readFileSync(join(appPrefix, 'content', file))
         const frontMatter = yamlFront.loadFront(fileContents);
 
-        postTags.push(frontMatter.tags);
+        if (frontMatter.tags) {
+          postTags.push(frontMatter.tags);
+        }
       });
 
       postTags = _.chain(postTags)

--- a/lib/automatic-new-tag.js
+++ b/lib/automatic-new-tag.js
@@ -19,17 +19,21 @@ module.exports = class AutomaticNewTag extends BroccoliPlugin {
 
       _.chain(markdownFiles)
         .map((file) => {
-          const fileContents = readFileSync(join(dir, file))
+          const fileContents = readFileSync(join(dir, file));
           return {
             frontMatter: yamlFront.loadFront(fileContents),
             file,
-          }
+          };
         })
         .sortBy(({frontMatter}) => {
           return new Date(frontMatter.date);
         })
         .reverse()
         .forEach(({file, frontMatter}, index) => {
+          if (!frontMatter.tags) {
+            frontMatter.tags = [];
+          }
+
           if (frontMatter.tags.includes('new')) {
             // eslint-disable-next-line no-console
             console.warn(`The tag "new" is deprecated, "new" is automatically added as a tag to the 4 most recent posts now. File: ${file}`);

--- a/tests/dummy/content/ember.md
+++ b/tests/dummy/content/ember.md
@@ -9,7 +9,6 @@ authors:
   - chris
 date: Tue Jun 12 2018 17:50:59 GMT+0100 (IST)
 tags:
-  - getting-started
 ---
 
 [Ember is a powerful Javascript Framework that is designed to maximise developer productivity](https://emberjs.com/). Ember also has one of the best plugin experiences in the industry, which means you can get a whole lot of functionality with just a simple `npm install`. If you want to check out the power of [Ember's addon ecosystem](https://emberobserver.com/) you can visit [Ember Observer](https://emberobserver.com/) which is made by [Code All Day](http://www.codeallday.com/).


### PR DESCRIPTION
Currently leaving `tags:` empty in a content yaml it would completely break the build. This PR adds support for that functionality while making sure the automatic new tag will also still be added.

@mansona we might want to, at the very least, add a post to the dummy app without a tag so the smoke test will catch this. Let me know how you want this to look.