### PR TITLE
Allow empty folders

### DIFF
--- a/lib/authors-array.js
+++ b/lib/authors-array.js
@@ -1,17 +1,20 @@
 const BroccoliPlugin = require('broccoli-plugin');
 const walkSync = require('walk-sync');
-const { readFileSync, writeFileSync } = require('fs');
+const { readFileSync, writeFileSync, existsSync } = require('fs');
 const { join } = require('path');
 const yamlFront = require('yaml-front-matter');
 const yaml = require('js-yaml');
 
 module.exports = class AuthorsArray extends BroccoliPlugin {
   constructor(folder, options) {
-    super([folder], options);
+    super(existsSync(folder) ? [folder] : [], options);
   }
 
   build() {
     this.inputPaths.forEach((dir) => {
+      if (!existsSync(dir)) {
+        return;
+      }
 
       const markdownFiles = walkSync(dir)
         .filter(path => path.endsWith('.md'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "broccoli-funnel": "^3.0.3",
         "broccoli-merge-trees": "^4.2.0",
         "broccoli-plugin": "^4.0.3",
-        "broccoli-static-site-json": "^4.2.0",
+        "broccoli-static-site-json": "^4.3.0",
         "broccoli-static-site-json-xml": "^1.0.1",
         "case": "^1.6.1",
         "downsize-cjs": "^0.1.1",
@@ -6227,9 +6227,9 @@
       }
     },
     "node_modules/broccoli-static-site-json": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/broccoli-static-site-json/-/broccoli-static-site-json-4.2.1.tgz",
-      "integrity": "sha512-jV2Cx5U/r3L3XtNJGPYMdEQLRdNSNUq9nQ954UhlGsnxFwKZ82yrfDdwaOXc/hRLwaF/ikoc0LhyRgMHz02lTw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/broccoli-static-site-json/-/broccoli-static-site-json-4.3.0.tgz",
+      "integrity": "sha512-gkuzQTV7sM3EHwmHtq311wmuOjRBaM4ITDvhQ50Ah175XAox5XfjbJ7nSeDpUHcU4Agxa1dvizJ4QCVqNYkzvQ==",
       "dependencies": {
         "broccoli-funnel": "^3.0.1",
         "broccoli-merge-trees": "^4.1.0",
@@ -34433,9 +34433,9 @@
       }
     },
     "broccoli-static-site-json": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/broccoli-static-site-json/-/broccoli-static-site-json-4.2.1.tgz",
-      "integrity": "sha512-jV2Cx5U/r3L3XtNJGPYMdEQLRdNSNUq9nQ954UhlGsnxFwKZ82yrfDdwaOXc/hRLwaF/ikoc0LhyRgMHz02lTw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/broccoli-static-site-json/-/broccoli-static-site-json-4.3.0.tgz",
+      "integrity": "sha512-gkuzQTV7sM3EHwmHtq311wmuOjRBaM4ITDvhQ50Ah175XAox5XfjbJ7nSeDpUHcU4Agxa1dvizJ4QCVqNYkzvQ==",
       "requires": {
         "broccoli-funnel": "^3.0.1",
         "broccoli-merge-trees": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "broccoli-funnel": "^3.0.3",
     "broccoli-merge-trees": "^4.2.0",
     "broccoli-plugin": "^4.0.3",
-    "broccoli-static-site-json": "^4.2.0",
+    "broccoli-static-site-json": "^4.3.0",
     "broccoli-static-site-json-xml": "^1.0.1",
     "case": "^1.6.1",
     "downsize-cjs": "^0.1.1",


### PR DESCRIPTION
This allows you to delete the `content` folder and also the `tag` folder without the build exploding. This doesn't go so far as allowing you to also delete the content folder or the author folders because those are pretty required.

If we think this doesn't go far enough we could add a quick check to the index.js file to give a more sensible error when they try to build without any content or authors 👍 