### PR TITLE
Make sure that examples are copy&pasteable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Next you will want to generate some posts. If you only have one author generated
 blog) you can generate a post as simply as running:
 
 ```sh
-npx ember g post "this is a post I want to write"
+npx ember g post "this is a post I want to write" --author=your-name
 ```
 
 ### Configuring


### PR DESCRIPTION
Provide --author parameter to generating post. It's mandatory so we might as well give a hint to the user to fill it in straight away.