### PR TITLE
add `node: current` to targets on install of empress-blog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12571,18 +12571,6 @@
         "symlink-or-copy": "^1.1.8"
       }
     },
-    "node_modules/ember-fetch/node_modules/broccoli-rollup/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/ember-fetch/node_modules/fast-sourcemap-concat": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-2.1.0.tgz",
@@ -15748,15 +15736,6 @@
         "quick-temp": "^0.1.3",
         "rimraf": "^2.3.4",
         "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/empress-blog-casper-template/node_modules/broccoli-persistent-filter/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "dependencies": {
-        "minimatch": "^3.0.2"
       }
     },
     "node_modules/empress-blog-casper-template/node_modules/broccoli-persistent-filter/node_modules/walk-sync": {
@@ -40373,15 +40352,6 @@
                 "path-posix": "^1.0.0",
                 "symlink-or-copy": "^1.1.8"
               }
-            },
-            "rimraf": {
-              "version": "2.7.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
             }
           }
         },
@@ -43049,15 +43019,6 @@
                 "quick-temp": "^0.1.3",
                 "rimraf": "^2.3.4",
                 "symlink-or-copy": "^1.1.8"
-              }
-            },
-            "matcher-collection": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-              "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-              "dev": true,
-              "requires": {
-                "minimatch": "^3.0.2"
               }
             },
             "walk-sync": {


### PR DESCRIPTION
This is just porting the implementation from https://github.com/ember-fastboot/ember-cli-fastboot/pull/770/files to empress-blog to make sure that new users aren't blocked.

I'm trying to get ember-cli-fastboot released this week if possible but I don't want to delay helping new users waiting for that release 🙈 