### PR TITLE
Remove step to install empress-blog in QuickStart

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npx ember-cli@latest new super-blog
 cd super-blog
 
 # you can replace the template with the one you want to use
-npx ember install empress-blog empress-blog-casper-template
+npx ember install empress-blog-casper-template
 ```
 
 It will ask you if you want to update the `index.html` file and you should say yes 👍


### PR DESCRIPTION
Following the Quickstart guide it suggests doing the following `npx ember install empress-blog empress-blog-casper-template` but that results in an error that `empress-blog` is not found. Removing `empress-blog` from the command allows the user to proceed to the next step (which also fails, but not sure the intended result so will follow up in separate issue or pr). 