### PR TITLE
make sure prember urls are prefixed with a /

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ Please generate tags using 'ember generate tag your-tag-name'`);
       .map(tag => `/tag/${tag}`)
       .value();
 
-    const contentUrls = content.map(file => file.replace(/\.md$/, ''));
+    const contentUrls = content.map(file => file.replace(/\.md$/, '')).map(file => `/${file}`);
 
     const pageUrls = walkSync(join(appPrefix, 'page'), {
       globs: ['*.md'],


### PR DESCRIPTION
I was made aware of this bug in a helpful hacker news comment (I know right 😂 ) where prembered urls were missing the `/` between the domain and the path for posts. This only happened with prember (i.e. not using ember-cli-fastboot or in the ember-only tests) so I figured it was something to do with how we defined the prember urls in the addon

I have tested that this works locally 👍 I would have to setup fastboot testing to add a test to make sure this works