### PR TITLE
update ember-scroll to 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "ember-decorators-polyfill": "^1.1.5",
         "ember-get-config": "^0.5.0",
         "ember-meta": "^2.0.0",
-        "ember-scroll": "^1.0.2",
+        "ember-scroll": "^1.0.3",
         "empress-blueprint-helpers": "^1.2.1",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.20",
@@ -16205,9 +16205,9 @@
       }
     },
     "node_modules/ember-scroll": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ember-scroll/-/ember-scroll-1.0.2.tgz",
-      "integrity": "sha512-/jfB/CgPE2wmoJZwDIoQSATdy/tuTddejDVGoEisgLcdUkA8vdKYrcKkwifpUSKlkLWJfrtD9J9oWylAp5CfnQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ember-scroll/-/ember-scroll-1.0.3.tgz",
+      "integrity": "sha512-iIB54xrzxpXmXvLfYWD6NrACYuD8o9+DZ4i/8ojd7szOVRp/pdBIm6GSsPcdcI4T2N98RPtquwhM27hvAOPYjA==",
       "dependencies": {
         "ember-cli-babel": "^7.21.0",
         "ember-cli-htmlbars": "^5.2.0",
@@ -44511,9 +44511,9 @@
       }
     },
     "ember-scroll": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ember-scroll/-/ember-scroll-1.0.2.tgz",
-      "integrity": "sha512-/jfB/CgPE2wmoJZwDIoQSATdy/tuTddejDVGoEisgLcdUkA8vdKYrcKkwifpUSKlkLWJfrtD9J9oWylAp5CfnQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ember-scroll/-/ember-scroll-1.0.3.tgz",
+      "integrity": "sha512-iIB54xrzxpXmXvLfYWD6NrACYuD8o9+DZ4i/8ojd7szOVRp/pdBIm6GSsPcdcI4T2N98RPtquwhM27hvAOPYjA==",
       "requires": {
         "ember-cli-babel": "^7.21.0",
         "ember-cli-htmlbars": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-decorators-polyfill": "^1.1.5",
     "ember-get-config": "^0.5.0",
     "ember-meta": "^2.0.0",
-    "ember-scroll": "^1.0.2",
+    "ember-scroll": "^1.0.3",
     "empress-blueprint-helpers": "^1.2.1",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.20",


### PR DESCRIPTION
Mostly because during my upgrade it still brought in 1.0.2 (even though we have ^1.0.2) and 1.0.3 contains a fix for Safari.